### PR TITLE
Example of using in module data to avoid PUP-6453 

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,0 +1,2 @@
+---
+wordpress_app::database_profile::port: '3306'

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,6 @@
+---
+version: 4
+datadir: 'data'
+hierarchy:
+  - name: 'common'
+    backend: 'yaml'

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -36,8 +36,9 @@ define wordpress_app::database(
     user       => "${user}@localhost",
   }
 }
+
 Wordpress_app::Database produces Database {
   host     => $::fqdn,
-  port     => '3306',
+  port     => lookup('wordpress_app::database_profile::port'),
   provider => 'tcp',
 }

--- a/manifests/database_profile.pp
+++ b/manifests/database_profile.pp
@@ -1,6 +1,16 @@
 class wordpress_app::database_profile (
+  # Must only be set with lookup or Wordpress_app::Database produces Database will be wrong
+  String $port,
   String $bind_address = '0.0.0.0',
 ) {
+
+  # If $port doesn't match the lookup value this should fail to prevent inaccurate
+  # database capabilities.
+  if ($port != lookup('wordpress_app::database_profile::port')) {
+    fail("\$wordpress_app::database_profile::port can only be set via puppet lookup.")
+  }
+
+  notify {"port is getting ${port}": }
   class { 'mysql::server':
     override_options => {
       'mysqld'       => {

--- a/metadata.json
+++ b/metadata.json
@@ -7,6 +7,7 @@
   "source": "https://github.com/puppetlabs/puppetlabs-wordpress_app",
   "project_page": "https://github.com/puppetlabs/puppetlabs-wordpress_app",
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
+  "data_provider": "hiera",
  "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",
@@ -59,7 +60,6 @@
     {"name":"hunner-wordpress","version_requirement":">=1.0.0 <2.0.0"},
     {"name":"hunner-wordpress","version_requirement":">=1.0.0 <2.0.0"},
     {"name":"jfryman-selinux","version_requirement":">=0.4.0 <0.5.0"}
-  ],
-  "data_provider": null
+  ]
 }
 


### PR DESCRIPTION
PUP-6453 prevents us from using class params of classes included in a
component in that components produced resources. This is a workaround
showing how you can use in module data to accomplish the same thing.

Instead of referencing the class param in the produce statement you can
use lookup to lookup the value of that class param. This won't work if a
user overrides the bound value of that param with an ENC or resource
like declaration.
