### PR TITLE
(ORCH-1479) Introduce basic rspec-puppet testing

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,12 @@
+fixtures:
+  repositories:
+    app_modeling: "https://github.com/puppetlabs/puppetlabs-app_modeling.git"
+    mysql: "https://github.com/puppetlabs/puppetlabs-mysql.git"
+    firewall: "https://github.com/puppetlabs/puppetlabs-firewall.git"
+    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
+    apache: "https://github.com/puppetlabs/puppetlabs-apache.git"
+    haproxy: "https://github.com/puppetlabs/puppetlabs-haproxy.git"
+    concat: "https://github.com/puppetlabs/puppetlabs-concat.git"
+    wordpress: "https://github.com/hunner/puppet-wordpress.git"
+  symlinks:
+    wordpress_app: "#{source_dir}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Final publish location for module build
+pkg/
+
+# VIM files
+*.swp
+
+# Mac files
+.DS_Store
+
+# Generated directory for coverage results
+coverage/
+
+# Gem & bundler related files we do not want persisted to the repository
+Gemfile.lock
+.bundle
+vendor/
+
+# Used by rake spec, for temp modules and other test requirements
+spec/fixtures/
+
+# RVM files that are specific to developers implementation
+.ruby-version
+.ruby-gemset

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: ruby
+bundler_args: --without development
+script: "bundle exec rake lint spec SPEC_OPTS='--format documentation'"
+rvm:
+  - 2.1.10
+  - 2.2.5
+  - 2.3.1
+env:
+  - PUPPET_GEM_VERSION="~> 4.0"
+notifications:
+  email: false

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,10 @@ source 'https://rubygems.org'
 
 puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['>= 3.3']
 gem 'puppet', puppetversion
-gem 'puppetlabs_spec_helper', '>= 0.8.2'
-gem 'puppet-lint', '>= 1.0.0'
 gem 'facter', '>= 1.7.0'
+
+group :development, :test do
+  gem 'puppetlabs_spec_helper', '>= 1.1.1'
+  gem 'puppet-lint', '>= 2.0.0'
+  gem 'rspec-puppet', '>= 2.4.0'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,17 +1,10 @@
-require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
-PuppetLint.configuration.send('disable_80chars')
-PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
+require 'puppetlabs_spec_helper/rake_tasks'
 
-desc "Validate manifests, templates, and ruby files"
-task :validate do
-  Dir['manifests/**/*.pp'].each do |manifest|
-    sh "puppet parser validate --noop #{manifest}"
-  end
-  Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
-    sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
-  end
-  Dir['templates/**/*.erb'].each do |template|
-    sh "erb -P -x -T '-' #{template} | ruby -c"
-  end
-end
+PuppetLint.configuration.fail_on_warnings = true
+PuppetLint.configuration.send('relative')
+PuppetLint.configuration.send('disable_140chars')
+PuppetLint.configuration.send('disable_class_inherits_from_params_class')
+PuppetLint.configuration.send('disable_documentation')
+PuppetLint.configuration.send('disable_single_quote_string_with_variables')
+PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp", "bundle/**/*", "vendor/**/*"]

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,7 +1,0 @@
-require 'spec_helper'
-describe 'wordpress_app' do
-
-  context 'with defaults for all parameters' do
-    it { should contain_class('wordpress_app') }
-  end
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,11 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+
+
+RSpec.configure do |c|
+  c.before(:each) do
+    Puppet[:app_management] = true
+  end
+  c.after(:suite) do
+    RSpec::Puppet::Coverage.report!
+  end
+end

--- a/spec/unit/classes/database_profile_spec.rb
+++ b/spec/unit/classes/database_profile_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'wordpress_app::database_profile', :type => :class do
+  context 'with defaults for all parameters' do
+    let(:facts) {{
+      :operatingsystem => 'CentOS',
+      :operatingsystemmajrelease => '7',
+      :osfamily => 'Redhat',
+    }}
+
+    it { should contain_class('wordpress_app::database_profile') }
+  end
+end

--- a/spec/unit/classes/ruby_spec.rb
+++ b/spec/unit/classes/ruby_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'wordpress_app::ruby', :type => :class do
+  context 'with defaults for all parameters' do
+    it { should contain_class('wordpress_app::ruby') }
+  end
+end

--- a/spec/unit/classes/web_profile_spec.rb
+++ b/spec/unit/classes/web_profile_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'wordpress_app::web_profile', :type => :class do
+  context 'with defaults for all parameters' do
+    let(:facts) {{
+      :operatingsystem => 'CentOS',
+      :operatingsystemrelease => '7.0',
+      :operatingsystemmajrelease => '7',
+      :osfamily => 'RedHat',
+    }}
+    it { should contain_class('wordpress_app::web_profile') }
+  end
+end

--- a/spec/unit/defines/database_spec.rb
+++ b/spec/unit/defines/database_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'wordpress_app::database', :type => :define do
+  let :title do
+    'test'
+  end
+
+  let(:facts) {{
+    :operatingsystem => 'CentOS',
+    :operatingsystemmajrelease => '7',
+    :osfamily => 'Redhat',
+  }}
+
+  describe 'should work with only default parameters' do
+    it { is_expected.to contain_wordpress_app__database('test') }
+  end
+end

--- a/spec/unit/defines/lb_spec.rb
+++ b/spec/unit/defines/lb_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe 'wordpress_app::lb', :type => :define do
+  let(:facts) {{
+    :operatingsystem => 'CentOS',
+    :operatingsystemmajrelease => '7',
+    :osfamily => 'RedHat',
+    :ipaddress => '1.1.1.1',
+  }}
+
+  let :title do
+    'test'
+  end
+  let(:params) {{
+    :balancermembers => [{
+      "host" => 'foo',
+      "ip" => '1.1.1.1',
+      "port" => 80,
+    }]
+  }}
+
+  describe 'should work with only default parameters' do
+    it { is_expected.to contain_wordpress_app__lb('test') }
+  end
+end

--- a/spec/unit/defines/web_spec.rb
+++ b/spec/unit/defines/web_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'wordpress_app::web', :type => :define do
+  let(:facts) {{
+    :operatingsystem => 'CentOS',
+    :operatingsystemrelease => '7.0',
+    :operatingsystemmajrelease => '7',
+    :osfamily => 'RedHat',
+    :ipaddress => '1.1.1.1',
+  }}
+
+  let :title do
+    'test'
+  end
+
+  let(:params) {{
+    :db_host => 'foo',
+    :db_name => 'foo',
+    :db_user => 'foo',
+    :db_password => 'foo',
+  }}
+
+  describe 'should work with only default parameters' do
+    it { is_expected.to contain_wordpress_app__web('test') }
+  end
+end


### PR DESCRIPTION
This patch provides the most basic coverage for rspec-puppet for the component
types that currently work. It also prepares travis CI for unit testing.

Signed-off-by: Ken Barber ken@bob.sh
