### PR TITLE
(MODULES-3647) Fix haproxy dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -57,7 +57,7 @@
     {"name":"puppetlabs-mysql","version_requirement":">=3.0.0 <4.0.0"},
     {"name":"puppetlabs-apache","version_requirement":">=1.0.0 <2.0.0"},
     {"name":"hunner-wordpress","version_requirement":">=1.0.0 <2.0.0"},
-    {"name":"hunner-wordpress","version_requirement":">=1.0.0 <2.0.0"},
+    {"name":"puppetlabs-haproxy","version_requirement":">=1.3.0 <2.0.0"},
     {"name":"jfryman-selinux","version_requirement":">=0.4.0 <0.5.0"}
   ],
   "data_provider": null


### PR DESCRIPTION
haproxy was missing from metadata.json, and wordpress was listed twice.

Signed-off-by: Ken Barber ken@bob.sh
