### PR TITLE
(ORCH-1518) Add basic application testing coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,8 @@ gem 'facter', '>= 1.7.0'
 group :development, :test do
   gem 'puppetlabs_spec_helper', '>= 1.1.1'
   gem 'puppet-lint', '>= 2.0.0'
-  gem 'rspec-puppet', '>= 2.4.0'
+  # Temporarily pin until released:
+  #   https://github.com/rodjek/rspec-puppet/pull/411
+  gem 'rspec-puppet', '>= 2.4.0', :git => 'https://github.com/rodjek/rspec-puppet.git',
+                                  :ref => 'd1a7233eec08a2c605b623ced2b863c5ea4b37df'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,6 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
 
-
 RSpec.configure do |c|
-  c.before(:each) do
-    Puppet[:app_management] = true
-  end
   c.after(:suite) do
     RSpec::Puppet::Coverage.report!
   end

--- a/spec/unit/applications/init_spec.rb
+++ b/spec/unit/applications/init_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+describe 'wordpress_app', :type => :application do
+  let :facts do
+    {
+      :operatingsystem => 'CentOS',
+      :operatingsystemrelease => '7.0',
+      :operatingsystemmajrelease => '7',
+      :osfamily => 'RedHat',
+      :ipaddress => '1.1.1.1',
+    }
+  end
+
+  let(:title) { 'public_blog' }
+
+  context "on a single node setup" do
+    let(:node) { 'blog.puppet.com' }
+
+    let :params do
+      {
+        :nodes => {
+          ref('Node', node) => [
+            ref('Wordpress_app::Lb', 'blog_lb'),
+            ref('Wordpress_app::Web', 'blog_web'),
+            ref('Wordpress_app::Database', 'blog_database'),
+          ]
+        }
+      }
+    end
+
+    context 'with defaults for all parameters' do
+      it { should compile }
+      it { should contain_wordpress_app(title).with(
+                    'database' => 'wordpress',
+                    'db_user' => 'wordpress',
+                    'db_pass' => 'wordpress',
+                    'web_int' => '',
+                    'web_port' => 8080,
+                    'lb_ipaddress' => '0.0.0.0',
+                    'lb_port' => '80',
+                    'lb_balance_mode' => 'roundrobin',
+                    'lb_options' => ['forwardfor', 'http-server-close', 'httplog'],
+                  ) }
+      it { should contain_wordpress_app__lb('blog_lb').with(
+                    'lb_options' => ['forwardfor', 'http-server-close', 'httplog'],
+                    'ipaddress' => '0.0.0.0',
+                    'port' => '80',
+                  ) }
+      it { should contain_wordpress_app__web('blog_web').with(
+                    'db_host' => node,
+                    'db_name' => 'wordpress',
+                    'db_user' => 'wordpress',
+                    'db_password' => 'wordpress',
+                    'interface' => '',
+                    'apache_port' => 8080,
+                  ) }
+      it { should contain_wordpress_app__database('blog_database').with(
+                    'database' => 'wordpress',
+                    'user' => 'wordpress',
+                    'password' => 'wordpress',
+                  ) }
+    end
+  end
+end

--- a/spec/unit/applications/simple_spec.rb
+++ b/spec/unit/applications/simple_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+describe 'wordpress_app::simple', :type => :application do
+  let :facts do
+    {
+      :operatingsystem => 'CentOS',
+      :operatingsystemrelease => '7.0',
+      :operatingsystemmajrelease => '7',
+      :osfamily => 'RedHat',
+      :ipaddress => '1.1.1.1',
+    }
+  end
+
+  let(:title) { 'public_blog' }
+
+  context "on a single node" do
+    let(:node) { 'blog.puppet.com' }
+
+    let :params do
+      {
+        :nodes => {
+          ref('Node', node) => [
+            ref('Wordpress_app::Lb', title),
+            ref('Wordpress_app::Web', title),
+            ref('Wordpress_app::Database', title),
+          ]
+        }
+      }
+    end
+
+    context 'with defaults for all parameters' do
+      it { should compile }
+      it { should contain_wordpress_app__simple(title).with(
+                    'database' => 'wordpress',
+                    'db_user' => 'wordpress',
+                    'db_pass' => 'wordpress',
+                    'web_port' => 8080,
+                    'lb_port' => '80',
+                  ) }
+      it { should contain_wordpress_app__lb(title).with(
+                    'lb_options' => ['forwardfor', 'http-server-close', 'httplog'],
+                    'ipaddress' => '0.0.0.0',
+                    'port' => '80',
+                  ) }
+      it { should contain_wordpress_app__web(title).with(
+                    'db_host' => node,
+                    'db_name' => 'wordpress',
+                    'db_user' => 'wordpress',
+                    'db_password' => 'wordpress',
+                    'interface' => '',
+                    'apache_port' => 8080,
+                  ) }
+      it { should contain_wordpress_app__database(title).with(
+                    'database' => 'wordpress',
+                    'user' => 'wordpress',
+                    'password' => 'wordpress',
+                  ) }
+    end
+  end
+end

--- a/spec/unit/classes/database_profile_spec.rb
+++ b/spec/unit/classes/database_profile_spec.rb
@@ -1,13 +1,16 @@
 require 'spec_helper'
 
 describe 'wordpress_app::database_profile', :type => :class do
-  context 'with defaults for all parameters' do
-    let(:facts) {{
+  let :facts do
+    {
       :operatingsystem => 'CentOS',
       :operatingsystemmajrelease => '7',
       :osfamily => 'Redhat',
-    }}
+    }
+  end
 
+  context 'with defaults for all parameters' do
+    it { should compile }
     it { should contain_class('wordpress_app::database_profile') }
   end
 end

--- a/spec/unit/classes/ruby_spec.rb
+++ b/spec/unit/classes/ruby_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe 'wordpress_app::ruby', :type => :class do
   context 'with defaults for all parameters' do
+    it { should compile }
     it { should contain_class('wordpress_app::ruby') }
   end
 end

--- a/spec/unit/classes/web_profile_spec.rb
+++ b/spec/unit/classes/web_profile_spec.rb
@@ -1,13 +1,17 @@
 require 'spec_helper'
 
 describe 'wordpress_app::web_profile', :type => :class do
-  context 'with defaults for all parameters' do
-    let(:facts) {{
+  let :facts do
+    {
       :operatingsystem => 'CentOS',
       :operatingsystemrelease => '7.0',
       :operatingsystemmajrelease => '7',
       :osfamily => 'RedHat',
-    }}
+    }
+  end
+
+  context 'with defaults for all parameters' do
+    it { should compile }
     it { should contain_class('wordpress_app::web_profile') }
   end
 end

--- a/spec/unit/defines/database_spec.rb
+++ b/spec/unit/defines/database_spec.rb
@@ -1,17 +1,18 @@
 require 'spec_helper'
 
 describe 'wordpress_app::database', :type => :define do
-  let :title do
-    'test'
+  let :facts do
+    {
+      :operatingsystem => 'CentOS',
+      :operatingsystemmajrelease => '7',
+      :osfamily => 'Redhat',
+    }
   end
 
-  let(:facts) {{
-    :operatingsystem => 'CentOS',
-    :operatingsystemmajrelease => '7',
-    :osfamily => 'Redhat',
-  }}
+  let(:title) { 'public_blog' }
 
-  describe 'should work with only default parameters' do
-    it { is_expected.to contain_wordpress_app__database('test') }
+  context 'with defaults for all parameters' do
+    it { should compile }
+    it { should contain_wordpress_app__database('public_blog') }
   end
 end

--- a/spec/unit/defines/lb_spec.rb
+++ b/spec/unit/defines/lb_spec.rb
@@ -1,25 +1,31 @@
 require 'spec_helper'
 
 describe 'wordpress_app::lb', :type => :define do
-  let(:facts) {{
-    :operatingsystem => 'CentOS',
-    :operatingsystemmajrelease => '7',
-    :osfamily => 'RedHat',
-    :ipaddress => '1.1.1.1',
-  }}
-
-  let :title do
-    'test'
+  let :facts do
+    {
+      :operatingsystem => 'CentOS',
+      :operatingsystemmajrelease => '7',
+      :osfamily => 'RedHat',
+      :ipaddress => '1.1.1.1',
+    }
   end
-  let(:params) {{
-    :balancermembers => [{
-      "host" => 'foo',
-      "ip" => '1.1.1.1',
-      "port" => 80,
-    }]
-  }}
 
-  describe 'should work with only default parameters' do
-    it { is_expected.to contain_wordpress_app__lb('test') }
+  let(:title) { 'public_blog' }
+
+  let(:params) do
+    {
+      :balancermembers => [
+        {
+          "host" => 'foo',
+          "ip" => '1.1.1.1',
+          "port" => 80,
+        }
+      ]
+    }
+  end
+
+  context 'with defaults for all parameters' do
+    it { should compile }
+    it { should contain_wordpress_app__lb('public_blog') }
   end
 end

--- a/spec/unit/defines/web_spec.rb
+++ b/spec/unit/defines/web_spec.rb
@@ -1,26 +1,30 @@
+# coding: utf-8
 require 'spec_helper'
 
 describe 'wordpress_app::web', :type => :define do
-  let(:facts) {{
-    :operatingsystem => 'CentOS',
-    :operatingsystemrelease => '7.0',
-    :operatingsystemmajrelease => '7',
-    :osfamily => 'RedHat',
-    :ipaddress => '1.1.1.1',
-  }}
-
-  let :title do
-    'test'
+  let :facts do
+    {
+      :operatingsystem => 'CentOS',
+      :operatingsystemrelease => '7.0',
+      :operatingsystemmajrelease => '7',
+      :osfamily => 'RedHat',
+      :ipaddress => '1.1.1.1',
+    }
   end
 
-  let(:params) {{
-    :db_host => 'foo',
-    :db_name => 'foo',
-    :db_user => 'foo',
-    :db_password => 'foo',
-  }}
+  let(:title) { 'public_blog' }
 
-  describe 'should work with only default parameters' do
-    it { is_expected.to contain_wordpress_app__web('test') }
+  let :params do
+    {
+      :db_host => 'db.puppet.com',
+      :db_name => 'wordpress',
+      :db_user => 'wordpress_app',
+      :db_password => 'déjame_entrar_señor',
+    }
+  end
+
+  context 'with defaults for all parameters' do
+    it { should compile }
+    it { should contain_wordpress_app__web('public_blog') }
   end
 end


### PR DESCRIPTION
```
This patch utilises the new features available in rspec-puppet to test
the wordpress_app and wordpress_app::simple applications on a basic level.

Signed-off-by: Ken Barber <ken@bob.sh>
```
